### PR TITLE
Test::Fatal conversion

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,8 @@ Revision history for MooseX-Aliases
 {{$NEXT}}
       - Update Moose dep to make 'use MooseX::Aliases' work properly in roles.
       - New Dist::Zilla stuff.
+      - The test suite now uses Test::Fatal instead of Test::Exception (Karen
+        Etheridge).
 
 0.08  2010-01-17
       - Fix metarole usage for new role metarole interface (autarch).

--- a/dist.ini
+++ b/dist.ini
@@ -10,4 +10,4 @@ dist = MooseX-Aliases
 
 [Prereq]
 Moose = 1.09
-Test::Exception = 0
+Test::Fatal = 0.003

--- a/dist.ini
+++ b/dist.ini
@@ -8,6 +8,6 @@ copyright_holder = Jesse Luehrs
 [@DOY]
 dist = MooseX-Aliases
 
-[Prereq]
+[Prereqs]
 Moose = 1.09
 Test::Fatal = 0.003

--- a/t/10-errors.t
+++ b/t/10-errors.t
@@ -2,7 +2,7 @@
 use strict;
 use warnings;
 use Test::More tests => 3;
-use Test::Exception;
+use Test::Fatal;
 use Test::Moose;
 
 {
@@ -10,8 +10,8 @@ use Test::Moose;
     use Moose;
     use MooseX::Aliases;
 
-    ::throws_ok { alias foo => 'bar' } qr/^Cannot find method bar to alias/,
-        "aliasing a non-existent method gives an appropriate error";
+    ::like( ::exception { alias foo => 'bar' }, qr/^Cannot find method bar to alias/,
+        "aliasing a non-existent method gives an appropriate error");
 
     has foo => (
         is    => 'ro',
@@ -21,7 +21,7 @@ use Test::Moose;
 }
 
 with_immutable {
-    throws_ok { Foo->new(bar => 1, baz => 2) }
+    like( exception { Foo->new(bar => 1, baz => 2) },
               qr/^Conflicting init_args: \(bar, baz\)/,
-              "conflicting init_args give an appropriate error";
+              "conflicting init_args give an appropriate error");
 } 'Foo';


### PR DESCRIPTION
Test::Fatal is the new hotness.

PS. can't 'dzil build', getting:
Attribute (template) does not pass the type constraint because: Couldn't read file /Users/ether/.dzil/pod_templates/bugs.section at /usr/local/lib/site_perl/5.12.1/Pod/Weaver.pm line 141

09:29 < ether> what do I need to put in this file to resolve build errors like 
               'Couldn't read file 
               /Users/ether/.dzil/pod_templates/bugs.section' ?
09:30 @rafl a) #distzilla  b) yell at the author (doy, right?) for shipping a 
              dist.ini that isn't self-contained
09:31 < ether> yes doy
09:31 @rafl he used to do it for a while until he figured out how to do it 
              properly or was yelled at for long enough or something. probably 
              not all dists updated yet
