### PR TITLE
Missing Test::Moose dependency

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -14,3 +14,4 @@ Moose = 1.09
 [Prereqs / TestRequires]
 Test::Fatal    = 0.003
 Test::Requires = 0
+Test::Moose    = 0


### PR DESCRIPTION
MooseX::Aliases requires Test::Moose at build-time, but this requirement is not mentioned in META.json, causing it not to be automatically installed by CPAN.

Cheers.
