### PR TITLE
Doc patch for RT#73790

### DIFF
--- a/lib/MooseX/Aliases.pm
+++ b/lib/MooseX/Aliases.pm
@@ -131,6 +131,65 @@ sub alias {
     );
 }
 
+=head1 ALIASING VERSUS OTHER MOOSE FEATURES
+
+=head2 Aliasing versus inheritance
+
+    {
+        package Parent;
+        use Moose;
+        use MooseX::Aliases;
+        sub method1 { "A" }
+        alias method2 => "method1";
+    }
+    
+    {
+        package Child1;
+        use Moose;
+        extends "Parent";
+        sub method1 { "B" }
+    }
+    
+    {
+        package Child2;
+        use Moose;
+        extends "Parent";
+        sub method2 { "C" }
+    }
+
+In the example above, Child1 overrides the method using its
+original name (C<method1>). As a result, calling C<method1> or
+C<method2> returns "B". Child2 overrides the method using its
+alias (C<method2>). As a result, calling C<method2> returns "C",
+but calling C<method1> falls through to the parent class, so
+returns "A".
+
+=head2 Aliasing versus method modifiers
+
+    {
+        package Class1;
+        use Moose;
+        use MooseX::Aliases;
+        sub method1 { "A" }
+        alias method2 => "method1";
+        around method1 => sub { "B" };
+    }
+    
+    {
+        package Class2;
+        use Moose;
+        use MooseX::Aliases;
+        sub method1 { "A" }
+        alias method2 => "method1";
+        around method2 => sub { "B" };
+    }
+
+In the example above, Class1's around modifier modifies the 
+method using its original name. As a result, both C<method1>
+and C<method2> return "B". Class2's around modifier modifies
+the alias, so C<method2> returns "B", but C<method1> continues
+to return "A".
+
 =head1 CAVEATS
 
 The order of arguments for the C<alias> method has changed (as of version

--- a/t/21-versus-inheritance.t
+++ b/t/21-versus-inheritance.t
@@ -1,0 +1,38 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 12;
+use Test::Moose;
+
+{
+    package Parent;
+    use Moose;
+    use MooseX::Aliases;
+    sub method1 { "A" }
+    alias method2 => "method1";
+}
+
+{
+    package Child1;
+    use Moose;
+    extends "Parent";
+    sub method1 { "B" }
+}
+
+{
+    package Child2;
+    use Moose;
+    extends "Parent";
+    sub method2 { "C" }
+}
+
+with_immutable {
+    
+    is( 'Parent'->method1, 'A' );
+    is( 'Parent'->method2, 'A' );
+    is( 'Child1'->method1, 'B' );
+    is( 'Child1'->method2, 'B' );
+    is( 'Child2'->method1, 'A' );
+    is( 'Child2'->method2, 'C' );
+    
+} qw( Parent Child1 Child2 );

--- a/t/22-versus-modifiers.t
+++ b/t/22-versus-modifiers.t
@@ -1,0 +1,32 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::More tests => 8;
+use Test::Moose;
+
+{
+    package Class1;
+    use Moose;
+    use MooseX::Aliases;
+    sub method1 { "A" }
+    alias method2 => "method1";
+    around method1 => sub { "B" };
+}
+
+{
+    package Class2;
+    use Moose;
+    use MooseX::Aliases;
+    sub method1 { "A" }
+    alias method2 => "method1";
+    around method2 => sub { "B" };
+}
+
+with_immutable {
+    
+    is( 'Class1'->method1, 'B' );
+    is( 'Class1'->method2, 'B' );
+    is( 'Class2'->method1, 'A' );
+    is( 'Class2'->method2, 'B' );
+    
+} qw( Class1 Class2 );


### PR DESCRIPTION
This documents how MooseX::Aliases works with inheritance, and with method modifiers.

Test cases are included based on the examples in the documentation, to help ensure no regressions against documented behaviour.
