### PR TITLE
Moose 2.1100 Exceptions fixes

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -26,4 +26,7 @@ namespace = MooseX::Aliases::Meta
 skip = ^(?:MyApp|MyTest)
 skip = ^Parent|Foo$
 
+[RemovePrereqs]
+remove = Moose::Exception 
+
 [ContributorsFromGit]

--- a/lib/Moose/Exception/Aliases/AliasedMethodMissing.pm
+++ b/lib/Moose/Exception/Aliases/AliasedMethodMissing.pm
@@ -1,0 +1,19 @@
+package Moose::Exception::Aliases::AliasedMethodMissing;
+
+# ABSTRACT: A specified method to create an alias for does not exist
+
+use Moose;
+extends 'Moose::Exception';
+
+has 'original_method' => (
+    is       => 'ro',
+    isa      => 'Any',
+    required => 1,
+);
+
+sub _build_message {
+    my ($self) = @_;
+    return sprintf 'Cannot find method %s to alias', $self->original_method;
+}
+
+1;

--- a/lib/Moose/Exception/Aliases/InitArgConflict.pm
+++ b/lib/Moose/Exception/Aliases/InitArgConflict.pm
@@ -1,0 +1,20 @@
+package Moose::Exception::Aliases::InitArgConflict;
+
+# ABSTRACT: Too many aliases for C<init_args>
+
+use Moose;
+extends 'Moose::Exception';
+
+has 'init_arg_aliases' => (
+    is       => 'ro',
+    isa      => 'ArrayRef',
+    required => 1,
+);
+
+sub _build_message {
+    my ($self) = @_;
+    return sprintf 'Conflicting init_args: (%s)',
+      ( join q{, }, @{ $self->init_arg_aliases } );
+}
+
+1;


### PR DESCRIPTION
This patch set works for me to make MX:Aliases function on `Moose 2.1100+`
